### PR TITLE
Fixed RD-14975: Do not push LIMIT when OFFSET is specified

### DIFF
--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -70,7 +70,7 @@ typedef struct MulticornPlanState
     int			startupCost;
     ConversionInfo **cinfos;
     List	   *pathkeys; /* list of MulticornDeparsedSortGroup) */
-    double		limit; /* store the LIMIT value, or -1 if no limit */
+    int64		limit; /* store the LIMIT value, or -1 if no limit */
     uint64		plan_id; /* unique identifier for this plan */
 
     /* For some reason, `baserel->reltarget->width` gets changed
@@ -93,7 +93,7 @@ typedef struct MulticornExecState
     List	   *qual_list;
     Datum	   *values;
     bool	   *nulls;
-    double	  	limit; /* store the LIMIT value, or -1 if no limit */
+    int64	  	limit; /* store the LIMIT value, or -1 if no limit */
     uint64	   	plan_id; /* unique identifier for this plan */
     ConversionInfo **cinfos;
     /* Common buffer to avoid repeated allocations */

--- a/src/python.c
+++ b/src/python.c
@@ -998,7 +998,7 @@ execute(ForeignScanState *node, ExplainState *es)
         }
         /* Set the limit optional argument if there is a LIMIT clause. */
         if(state->limit != -1) {
-            PyDict_SetItemString(kwargs, "limit", PyFloat_FromDouble(state->limit));
+            PyDict_SetItemString(kwargs, "limit", PyLong_FromLongLong(state->limit));
         }
 
         if(es != NULL){


### PR DESCRIPTION
Added the logic to skip `LIMIT` when `OFFSET` is found. It includes checking if `OFFSET` is zero or `NULL` (in which case it behaves as "no offset".

`LIMIT` is extracted from the expression `Node`. If `NULL`, it's ignored (as the semantic says), and it's forwarded as an `INT64`.

It was tested by executing various combinations of `LIMIT` and `OFFSET` and checking if `LIMIT` is sent or not.
```sql
SELECT name FROM ... ORDER BY name ASC LIMIT 3; -- sent (no offset)
SELECT name FROM ... ORDER BY name ASC OFFSET NULL LIMIT 3 ; -- sent (no real offset)
SELECT name FROM ... ORDER BY name ASC OFFSET 0 LIMIT 3 ; -- sent (no real offset)
SELECT name FROM ... ORDER BY name ASC OFFSET 1 LIMIT 3; -- not sent (offset present)

SELECT name FROM ... ORDER BY name ASC LIMIT 0; -- Postgres doesn't call 'execute'
SELECT name FROM ... ORDER BY name ASC LIMIT NULL; -- LIMIT not sent
SELECT name FROM ... ORDER BY name ASC LIMIT ALL; -- LIMIT not sent
```