### PR TITLE
RD-14972: Support for nested types

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
 srcdir       = .
 MODULE_big   = multicorn
 OBJS         =  src/errors.o src/python.o src/query.o src/multicorn.o
-PG_CFLAGS = -g -O0
+# Uncomment to have symbols in debuggers
+# PG_CFLAGS = -g -O0
 
 
 DATA         = $(filter-out $(wildcard sql/*--*.sql),$(wildcard sql/*.sql))
@@ -97,7 +98,7 @@ else
 	# --embed required for Py >= 3.8
 	PY_LIBSPEC = $(shell ${PYTHON_CONFIG} --embed >/dev/null && ${PYTHON_CONFIG} --libs --embed || ${PYTHON_CONFIG} --libs)
 	PY_INCLUDESPEC = $(shell ${PYTHON_CONFIG} --includes)
-	PY_CFLAGS = $(shell ${PYTHON_CONFIG} --cflags) -g
+	PY_CFLAGS = $(shell ${PYTHON_CONFIG} --cflags)
 	PY_LDFLAGS = $(shell ${PYTHON_CONFIG} --ldflags)
 	SHLIB_LINK += $(PY_LIBSPEC) $(PY_LDFLAGS) $(PY_ADDITIONAL_LIBS) $(filter -lintl,$(LIBS))
 	override PG_CPPFLAGS  := $(PY_INCLUDESPEC) $(PG_CPPFLAGS)

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 srcdir       = .
 MODULE_big   = multicorn
 OBJS         =  src/errors.o src/python.o src/query.o src/multicorn.o
+PG_CFLAGS = -g -O0
 
 
 DATA         = $(filter-out $(wildcard sql/*--*.sql),$(wildcard sql/*.sql))
@@ -96,7 +97,7 @@ else
 	# --embed required for Py >= 3.8
 	PY_LIBSPEC = $(shell ${PYTHON_CONFIG} --embed >/dev/null && ${PYTHON_CONFIG} --libs --embed || ${PYTHON_CONFIG} --libs)
 	PY_INCLUDESPEC = $(shell ${PYTHON_CONFIG} --includes)
-	PY_CFLAGS = $(shell ${PYTHON_CONFIG} --cflags)
+	PY_CFLAGS = $(shell ${PYTHON_CONFIG} --cflags) -g
 	PY_LDFLAGS = $(shell ${PYTHON_CONFIG} --ldflags)
 	SHLIB_LINK += $(PY_LIBSPEC) $(PY_LDFLAGS) $(PY_ADDITIONAL_LIBS) $(filter -lintl,$(LIBS))
 	override PG_CPPFLAGS  := $(PY_INCLUDESPEC) $(PG_CPPFLAGS)


### PR DESCRIPTION
* Any column that was advertised as JSON/JSONB is turned into JSON using Python's json package.
* Fixed a bug hit when processing nested types like arrays of nullable integers: the string builder renders `NULL` values as an empty string (it doesn't append any byte), which I imagine is handled by postgres when parsing a string as a top level column value (empty = null), but if that logic recursively applies to nested values, like in `[1, 2, NULL]`, then the string renders as `{1,2,}`, which Postgres fails to parse. Rendering `NULL` as `"NULL"` seems to work for both top-level and nested values.
```sql
# SELECT * FROM schema.nested ;
 listInt |     listList      | listNullables |               nested-record               |                     nested-record2                     | number |       record       | string  
---------+-------------------+---------------+-------------------------------------------+--------------------------------------------------------+--------+--------------------+---------
 {1,2,3} | {{1,2,3},{4,5,6}} | {1,2,NULL}    | {"a": {"a": 12, "b": 14}, "b": [1, 2, 3]} | {"a": {"a": 12, "b": 14}, "b": [[1, 2, 3], [4, 5, 6]]} |     12 | {"a": 12, "b": 14} | tralala
(1 row)
```