### PR TITLE
Fix crashes due to serializePlanState and initializeExecState picked from fdw

### DIFF
--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -118,7 +118,7 @@ static void multicorn_xact_callback(XactEvent event, void *arg);
 
 /*	Helpers functions */
 void	   *multicornSerializePlanState(MulticornPlanState * planstate);
-MulticornExecState *initializeExecState(void *internal_plan_state);
+MulticornExecState *multicornInitializeExecState(void *internal_plan_state);
 
 /* Hash table mapping oid to fdw instances */
 HTAB	   *InstancesHash;
@@ -597,7 +597,7 @@ multicornBeginForeignScan(ForeignScanState *node, int eflags)
     ListCell   *lc;
     elog(DEBUG3, "starting BeginForeignScan()");
 
-    execstate = initializeExecState(fscan->fdw_private);
+    execstate = multicornInitializeExecState(fscan->fdw_private);
     execstate->values = palloc(sizeof(Datum) * tupdesc->natts);
     execstate->nulls = palloc(sizeof(bool) * tupdesc->natts);
     execstate->qual_list = NULL;
@@ -1274,7 +1274,7 @@ multicornSerializePlanState(MulticornPlanState * state)
  *	MulticornExecState
  */
 MulticornExecState *
-initializeExecState(void *internalstate)
+multicornInitializeExecState(void *internalstate)
 {
     MulticornExecState *execstate = palloc0(sizeof(MulticornExecState));
     List	   *values = (List *) internalstate;

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -117,7 +117,7 @@ static List *multicornImportForeignSchema(ImportForeignSchemaStmt * stmt,
 static void multicorn_xact_callback(XactEvent event, void *arg);
 
 /*	Helpers functions */
-void	   *serializePlanState(MulticornPlanState * planstate);
+void	   *multicornSerializePlanState(MulticornPlanState * planstate);
 MulticornExecState *initializeExecState(void *internal_plan_state);
 
 /* Hash table mapping oid to fdw instances */
@@ -552,7 +552,7 @@ multicornGetForeignPlan(PlannerInfo *root,
                             scan_clauses,
                             scan_relid,
                             scan_clauses,		/* no expressions to evaluate */
-                            serializePlanState(planstate)
+                            multicornSerializePlanState(planstate)
                             , NULL
                             , NULL /* All quals are meant to be rechecked */
                             , NULL
@@ -1246,7 +1246,7 @@ multicornImportForeignSchema(ImportForeignSchemaStmt * stmt,
  *	between the plan and the execution safe.
  */
 void *
-serializePlanState(MulticornPlanState * state)
+multicornSerializePlanState(MulticornPlanState * state)
 {
     List	   *result = NULL;
 


### PR DESCRIPTION
We observed crashes due to these two functions having the same name as functions found in fdw.c. Runtime was calling the fdw.c ones and crashing.