### PR TITLE
RD-15088: Fix HSTORE array formatting

### DIFF
--- a/multicorn.control
+++ b/multicorn.control
@@ -2,3 +2,4 @@ comment = 'Multicorn2 Python3.9+ bindings for Postgres 12++ Foreign Data Wrapper
 default_version = '3.0'
 module_pathname = '$libdir/multicorn'
 relocatable = true
+requires = 'hstore'

--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -161,6 +161,7 @@ void		errorCheck(void);
 PyObject   *pgstringToPyUnicode(const char *string);
 char	  **pyUnicodeToPgString(PyObject *pyobject);
 
+void       setHstoreArrayOid(Oid oid);
 PyObject   *getInstance(Oid foreigntableid);
 PyObject   *qualToPyObject(Expr *expr, PlannerInfo *root);
 PyObject   *getClassString(const char *className);


### PR DESCRIPTION
* Added a dependency of the multicorn extension to the `hstore` one so that it can't be loaded/unloaded without `hstore`.
* Added logic to save the `_hstore` (`HSTORE` array) OID at startup so that we can compare the object OIDs to it while importing rows,
* Implemented the required specific HSTORE key/value formatter so that the regular postgres import works.
* Took the opportunity to add a couple more DEBUG logs and fix some compilation warnings.