### PR TITLE
RD-15143: decimals (numeric) sent as "python modules" + adding support for TIME

### DIFF
--- a/src/python.c
+++ b/src/python.c
@@ -1701,13 +1701,14 @@ datumBoolToPython(Datum datum, ConversionInfo * cinfo)
 static PyObject *
 datumDecimalToPython(Datum datum, ConversionInfo *cinfo)
 {
-    char *decimalStr;
-    PyObject *result;
+    char *decimalStr = StrDatumGetCString(DirectFunctionCall1(numeric_out, datum));
+    PyObject *p_decimal = PyImport_ImportModule("decimal");
+    PyObject *p_Decimal = PyObject_GetAttrString(p_decimal, "Decimal");
 
-    decimalStr = DatumGetCString(DirectFunctionCall1(numeric_out, datum));
+    PyObject *result = PyObject_CallFunction(p_Decimal, "s", decimalStr);
 
-    result = PyObject_CallFunction(PyImport_ImportModule("decimal")->ob_type, "s", decimalStr);
-
+    Py_DECREF(p_decimal);
+    Py_DECREF(p_Decimal);
     pfree(decimalStr);
 
     return result;

--- a/src/python.c
+++ b/src/python.c
@@ -88,6 +88,8 @@ void pymappingToCString(PyObject *pyobject, StringInfo buffer,
 void hstoreArrayToCString(PyObject *pyobject, Py_ssize_t size, StringInfo buffer);
 void pydateToCString(PyObject *pyobject, StringInfo buffer,
                 ConversionInfo * cinfo);
+void pytimeToCString(PyObject *pyobject, StringInfo buffer,
+                ConversionInfo * cinfo);
 
 void pyunknownToCstring(PyObject *pyobject, StringInfo buffer,
                    ConversionInfo * cinfo);
@@ -1295,6 +1297,20 @@ pydateToCString(PyObject *pyobject, StringInfo buffer,
     Py_DECREF(formatted_date);
 }
 
+void
+pytimeToCString(PyObject *pyobject, StringInfo buffer,
+                ConversionInfo * cinfo)
+{
+    char	   *tempbuffer;
+    Py_ssize_t	strlength = 0;
+    PyObject   *formatted_time;
+
+    formatted_time = PyObject_CallMethod(pyobject, "isoformat", "()");
+    PyString_AsStringAndSize(formatted_time, &tempbuffer, &strlength);
+    appendBinaryStringInfo(buffer, tempbuffer, strlength);
+    Py_DECREF(formatted_time);
+}
+
 
 void
 pyobjectToCString(PyObject *pyobject, StringInfo buffer,
@@ -1393,6 +1409,12 @@ pyobjectToCString(PyObject *pyobject, StringInfo buffer,
     {
         elog(DEBUG1, "Importing Python date (OID=%d)", cinfo->atttypoid);
         pydateToCString(pyobject, buffer, cinfo);
+        return;
+    }
+    if (PyTime_Check(pyobject))
+    {
+        elog(DEBUG1, "Importing Python time (OID=%d)", cinfo->atttypoid);
+        pytimeToCString(pyobject, buffer, cinfo);
         return;
     }
     elog(WARNING, "Unexpected type OID=%d, trying generic data import", cinfo->atttypoid);
@@ -1701,7 +1723,7 @@ datumBoolToPython(Datum datum, ConversionInfo * cinfo)
 static PyObject *
 datumDecimalToPython(Datum datum, ConversionInfo *cinfo)
 {
-    char *decimalStr = StrDatumGetCString(DirectFunctionCall1(numeric_out, datum));
+    char *decimalStr = DatumGetCString(DirectFunctionCall1(numeric_out, datum));
     PyObject *p_decimal = PyImport_ImportModule("decimal");
     PyObject *p_Decimal = PyObject_GetAttrString(p_decimal, "Decimal");
 


### PR DESCRIPTION
The original code was applying `PyImport_ImportModule("decimal")->ob_type` to the string rendition of a decimal. That's to say applying `type(decimal)` to `"3.14"`, which would lead to a `module` with name `3.14`:
```
>>> type(decimal)('3.14')
<module '3.14'>
```

I also added a specific handler for `TIME` instead of relying on the default logic. That would issue warnings all the time saying the type wasn't expected. 