### PR TITLE
Fixed RD-15246: expressions like current_date or x::varchar::timestamp lead to a wrong OID

### DIFF
--- a/src/python.c
+++ b/src/python.c
@@ -1022,7 +1022,7 @@ execute(ForeignScanState *node, ExplainState *es)
                     newqual->value = ExecEvalExpr(expr_state, econtext, &isNull, NULL);
                     #endif
                 }
-                newqual->base.typeoid = ((Param*) ((MulticornParamQual *) qual)->expr)->paramtype;
+                newqual->base.typeoid = ((MulticornBaseQual *) qual)->typeoid;
                 newqual->isnull = isNull;
                 break;
             case T_Const:


### PR DESCRIPTION
The code assumes expressions that aren't constants or variables (`T_Const` or `T_Var`) are parameters (`T_Param`). This isn't always the case:
* `current_date` is a `T_SQLValueFunction`
* `x::varchar::timestamp` leads to a `T_CoerceViaIO`

Eventually the data structure address that was stored isn't a `Param` in these cases. Extracting the expression type by reading `paramtype` just goes to a random offset in another data structure.
```c
newqual->base.typeoid = ((Param*) ((MulticornParamQual *) qual)->expr)->paramtype;
```
The patch consists in extracting the `typeoid` using a more universal option: a call to `get_expr_result_type`.

That function can fail to identify the type in complex cases (composite type not matching an OID, I haven't managed to trigger it). I added an error message if that happens. It would interrupt the query.