### PR TITLE
Fixed RD-15252: Missing handling of TIMESTAMPTZOID

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ srcdir       = .
 MODULE_big   = multicorn
 OBJS         =  src/errors.o src/python.o src/query.o src/multicorn.o
 # Uncomment to have symbols in debuggers
-PG_CFLAGS = -g -O0
+# PG_CFLAGS = -g -O0
 
 
 DATA         = $(filter-out $(wildcard sql/*--*.sql),$(wildcard sql/*.sql))


### PR DESCRIPTION
An expression like `NOW()` evaluates to a `TIMESTAMPTZ` which fails to be converted and is _sent as a string_. Which for example breaks a Salesforce predicate.
```sql
WHERE date < NOW();
```
```
[info] simple_qual {
[info]   operator: LESS_THAN
[info]   value {
[info]     string {
[info]       v: "2025-03-26 15:40:46.640026+01"
[info]     }
[info]   }
[info] }
```

The patch ensures it's processed like a timestamp and the query doesn't send it as a string but as a plain timestamp.
```sql
WHERE date < NOW();
```
```
[info] simple_qual {
[info]   operator: LESS_THAN
[info]   value {
[info]     timestamp {
[info]       year: 2025
[info]       month: 3
[info]       day: 26
[info]       hour: 15
[info]       minute: 42
[info]       second: 3
[info]       nano: 301429000
[info]     }
[info]   }
[info] }
```

It strips the time zone from the timestamp (since we don't have support for time zones) after performing a translation to the local timezone.
* `timestamp with time zone '2001-01-10 10:00:00+02:00'` => DAS value `2001-01-10 09:00:00`
* `timestamp with time zone '2001-01-10 10:00:00+01:00'` => DAS value `2001-01-10 10:00:00` (same time, Zurich)
* `timestamp with time zone '2001-01-10 10:00:00+00:00'` => DAS value `2001-01-10 11:00:00`
* `timestamp with time zone '2001-01-10 10:00:00-01:00'` => DAS value `2001-01-10 12:00:00`

Also fixed the missing microsecond value for timestamps in general.

```sql
WHERE x < timestamp '2001-01-10 10:12:34.123'
```
before:
```
[info]   value {
[info]     timestamp {
[info]       year: 2001
[info]       month: 1
[info]       day: 10
[info]       hour: 10
[info]       minute: 12
[info]       second: 34
[info]     }
```
after:
```
[info]   value {
[info]     timestamp {
[info]       year: 2001
[info]       month: 1
[info]       day: 10
[info]       hour: 10
[info]       minute: 12
[info]       second: 34
[info]       nano: 123000000
[info]     }
```