### PR TITLE
Fixed RD-15296: Multicorn FDW doesn't close/cancel the gRPC stream when a scan ends

### DIFF
--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -751,6 +751,10 @@ static void
 multicornEndForeignScan(ForeignScanState *node)
 {
     MulticornExecState *state = node->fdw_state;
+    if (state->p_iterator != NULL && state->p_iterator != Py_None) {
+        PyObject_CallMethod(state->p_iterator, "close", "()");
+        // ignore errors
+    }
     PyObject   *result = PyObject_CallMethod(state->fdw_instance, "end_scan", "()");
 
     errorCheck();

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -751,15 +751,40 @@ static void
 multicornEndForeignScan(ForeignScanState *node)
 {
     MulticornExecState *state = node->fdw_state;
-    if (state->p_iterator != NULL && state->p_iterator != Py_None) {
-        PyObject_CallMethod(state->p_iterator, "close", "()");
-        // ignore errors
-    }
     PyObject   *result = PyObject_CallMethod(state->fdw_instance, "end_scan", "()");
 
     errorCheck();
     Py_DECREF(result);
     Py_DECREF(state->fdw_instance);
+
+    if (state->p_iterator != NULL && state->p_iterator != Py_None) {
+        // Check if p_iterator has a 'close' method. Sometimes we get a ListIterator (e.g. EXPLAIN).
+        if (PyObject_HasAttrString(state->p_iterator, "close")) {
+            // Retrieve the 'close' method
+            PyObject *close_method = PyObject_GetAttrString(state->p_iterator, "close");
+            if (close_method && PyCallable_Check(close_method)) {
+                // Call the 'close' method with no arguments
+                PyObject *close_result = PyObject_CallObject(close_method, NULL);
+                if (close_result == NULL) {
+                    // An error occurred while calling 'close'
+                    PyErr_Print();
+                    // Ignore the error
+                } else {
+                    // Closed successfully
+                    Py_DECREF(close_result);
+                }
+                Py_DECREF(close_method);
+            } else {
+                // 'close' exists but is not callable or couldn't retrieve it
+                Py_XDECREF(close_method);
+                elog(WARNING, "Warning: 'close' attribute exists but is not callable.\n");
+            }
+        } else {
+            // 'close' method does not exist;
+            // We get that through EXPLAIN, UPDATE, DELETE. Iterator is backed by a list.
+        }
+    }
+
     Py_XDECREF(state->p_iterator);
     state->p_iterator = NULL;
 }


### PR DESCRIPTION
We cancel the stream when the scan is interrupted, but not when it ends normally.

It's fixed by hooking a call to `close` in `multicornEndForeignScan`. Another option is to add a handler as Python method `end_scan`, which is called there too. But that callback isn't parameterized, it cannot know which scan is interrupted, therefore which stream to close.