### PR TITLE
Fixed RD-15369: Generate a unique plan ID

### DIFF
--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -71,7 +71,7 @@ typedef struct MulticornPlanState
     ConversionInfo **cinfos;
     List	   *pathkeys; /* list of MulticornDeparsedSortGroup) */
     int64		limit; /* store the LIMIT value, or -1 if no limit */
-    uint64		plan_id; /* unique identifier for this plan */
+    char		plan_id[64]; /* unique identifier for this plan */
 
     /* For some reason, `baserel->reltarget->width` gets changed
      * outside of our control somewhere between GetForeignPaths and
@@ -94,7 +94,7 @@ typedef struct MulticornExecState
     Datum	   *values;
     bool	   *nulls;
     int64       limit; /* store the LIMIT value, or -1 if no limit */
-    uint64	   	plan_id; /* unique identifier for this plan */
+    char		plan_id[64]; /* unique identifier for this plan */
     ConversionInfo **cinfos;
     /* Common buffer to avoid repeated allocations */
     StringInfo	buffer;

--- a/src/python.c
+++ b/src/python.c
@@ -1076,7 +1076,7 @@ execute(ForeignScanState *node, ExplainState *es)
             errorCheck();
         } else {
             /* For execution, pass back the plan identifier. This allows the plugin to distinguish between different executions of the same plan node. */
-            PyDict_SetItemString(kwargs, "planid", PyLong_FromUnsignedLongLong(state->plan_id));
+            PyDict_SetItemString(kwargs, "planid", PyString_FromString(state->plan_id));
 
             p_method = PyObject_GetAttrString(state->fdw_instance, "execute");
             errorCheck();


### PR DESCRIPTION
We use the proc ID as a prefix to ensure plans are unique when the FDW is re-created upon new connections.