### PR TITLE
Pass environment from table "environment"

### DIFF
--- a/python/multicorn/__init__.py
+++ b/python/multicorn/__init__.py
@@ -269,7 +269,7 @@ class ForeignDataWrapper(object):
         """
         return []
 
-    def explain(self, quals, columns, sortkeys=None, limit=None, verbose=False):
+    def explain(self, env, quals, columns, sortkeys=None, limit=None, verbose=False):
         """Hook called on explain.
 
         The arguments are the same as the :meth:`execute`, with the addition of
@@ -280,7 +280,7 @@ class ForeignDataWrapper(object):
         """
         return []
 
-    def execute(self, quals, columns, sortkeys=None, limit=None, planid=None):
+    def execute(self, env, quals, columns, sortkeys=None, limit=None, planid=None):
         """Execute a query in the foreign data wrapper.
 
         This method is called at the first iteration.


### PR DESCRIPTION
A version that assumes a table called "environment" should be used to fill the `Environment` of a query. When the table doesn't exist, it's not populating the environment.