### PR TITLE
Support FDW-specific error codes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ srcdir       = .
 MODULE_big   = multicorn
 OBJS         =  src/errors.o src/python.o src/query.o src/multicorn.o
 # Uncomment to have symbols in debuggers
-# PG_CFLAGS = -g -O0
+PG_CFLAGS = -g -O0
 
 
 DATA         = $(filter-out $(wildcard sql/*--*.sql),$(wildcard sql/*.sql))

--- a/python/multicorn/utils.py
+++ b/python/multicorn/utils.py
@@ -21,12 +21,13 @@ REPORT_CODES = {
 
 
 class MulticornException(Exception):
-    def __init__(self, message, code, hint, detail):
+    def __init__(self, message, code, hint, detail, sqlstate=None):
         self._is_multicorn_exception = True
         self.message = message
         self.code = code
         self.hint = hint
         self.detail = detail
+        self.sqlstate = sqlstate
 
 
 def log_to_postgres(message, level=INFO, hint=None, detail=None):

--- a/python/multicorn/utils.py
+++ b/python/multicorn/utils.py
@@ -21,10 +21,15 @@ REPORT_CODES = {
 
 
 class MulticornException(Exception):
-    def __init__(self, message, code, hint, detail, sqlstate=None):
+    def __init__(self, message, level=ERROR, hint=None, detail=None, sqlstate=None):
         self._is_multicorn_exception = True
         self.message = message
+
+        code = REPORT_CODES.get(level, None)
+        if code is None:
+            raise KeyError("Not a valid log level")
         self.code = code
+
         self.hint = hint
         self.detail = detail
         self.sqlstate = sqlstate

--- a/src/errors.c
+++ b/src/errors.c
@@ -97,7 +97,7 @@ reportException(PyObject *pErrType, PyObject *pErrValue, PyObject *pErrTraceback
 #endif
             errmsg("Error in python: %s", errName);
 
-        /* In this code path, since errcode is not set, so this will fallback to an unclassified error code in Postgres. */
+        /* In this code path, errcode is not set. This will fallback to an unclassified error code in Postgres. */
 
         errdetail("%s", errValue);
         errdetail_log("%s", errTraceback);

--- a/src/errors.c
+++ b/src/errors.c
@@ -58,6 +58,7 @@ reportException(PyObject *pErrType, PyObject *pErrValue, PyObject *pErrTraceback
     PyObject   *pTemp;
     PyObject   *tracebackModule = PyImport_ImportModule("traceback");
     PyObject   *format_exception = PyObject_GetAttrString(tracebackModule, "format_exception");
+    
     PyObject   *newline = PyString_FromString("\n");
     int			severity;
 
@@ -68,8 +69,10 @@ reportException(PyObject *pErrType, PyObject *pErrValue, PyObject *pErrTraceback
     if (pErrTraceback != NULL)
     {
         traceback_list = PyObject_CallFunction(format_exception, "(O,O,O)", pErrType, pErrValue, pErrTraceback);
-        errTraceback = PyString_AsString(PyObject_CallMethod(newline, "join", "(O)", traceback_list));
+        PyObject   *joined_tb = PyObject_CallMethod(newline, "join", "(O)", traceback_list);
+        errTraceback = PyString_AsString(joined_tb);
         Py_DECREF(pErrTraceback);
+        Py_DECREF(joined_tb);
         Py_DECREF(traceback_list);
     }
 

--- a/src/python.c
+++ b/src/python.c
@@ -1471,6 +1471,7 @@ pyobjectToCString(PyObject *pyobject, StringInfo buffer,
         elog(DEBUG1, "Importing Python object as JSON (OID=%d)", cinfo->atttypoid);
         PyObject *multicorn_das = PyImport_ImportModule("multicorn_das");
         PyObject *p_to_json = PyObject_GetAttrString(multicorn_das, "multicorn_serialize_as_json");
+        errorCheck();
         PyObject *s = PyObject_CallFunction(p_to_json, "O", pyobject);
         Py_DECREF(multicorn_das);
         Py_DECREF(p_to_json);


### PR DESCRIPTION
For MulticornException, use FDW error code.
Optionally allow multicorn2 implementations to support passing their own error code as well.