### PR TITLE
Fixed RD-15379: Encode JSONB and HSTORE DAS values

### DIFF
--- a/src/multicorn.h
+++ b/src/multicorn.h
@@ -161,7 +161,9 @@ void		errorCheck(void);
 PyObject   *pgstringToPyUnicode(const char *string);
 char	  **pyUnicodeToPgString(PyObject *pyobject);
 
+void       setHstoreOid(Oid oid);
 void       setHstoreArrayOid(Oid oid);
+void       setHstoreToJsonbOid(Oid oid);
 PyObject   *getInstance(Oid foreigntableid);
 PyObject   *qualToPyObject(Expr *expr, PlannerInfo *root);
 PyObject   *getClassString(const char *className);


### PR DESCRIPTION
JSONB and HSTORE aren't sent as proper values by multicorn, they're passing through the default code path that turns them into strings.

Both are turned into JSONB (HSTORE comes with a function to turn an HSTORE to JSONB), and then we rely on the `json` Python module.

Tested `WHERE` predicates that compare jsonb, jsonb[], hstore and hstore[] columns. All the values were showing as regular DAS values.

## JSONB
```sql
SELECT records_col
FROM test.all_types
WHERE record_col = '{"a": 12, "b": "tralala"}'::jsonb;
```
```
[info]   quals {
[info]     name: "record_col"
[info]     simple_qual {
[info]       value {
[info]         record {
[info]           atts {
[info]             name: "a"
[info]             value {
[info]               int {
[info]                 v: 12
[info]               }
[info]             }
[info]           }
[info]           atts {
[info]             name: "b"
[info]             value {
[info]               string {
[info]                 v: "tralala"
[info]               }
[info]             }
[info]           }
[info]         }
[info]       }
[info]     }
[info]   }
```
## JSONB arrays
```sql
SELECT records_col
FROM test.all_types
WHERE records_col = ARRAY['{"a": 12, "b": "tralala"}'::jsonb];
```
```
[info]   quals {
[info]     name: "records_col"
[info]     simple_qual {
[info]       value {
[info]         list {
[info]           values {
[info]             record {
[info]               atts {
[info]                 name: "a"
[info]                 value {
[info]                   int {
[info]                     v: 12
[info]                   }
[info]                 }
[info]               }
[info]               atts {
[info]                 name: "b"
[info]                 value {
[info]                   string {
[info]                     v: "tralala"
[info]                   }
[info]                 }
[info]               }
[info]             }
[info]           }
[info]         }
[info]       }
[info]     }
[info]   }

```
## HSTORE
```sql
SELECT str_record_col, str_records_col, record_col, records_col
FROM test.all_types
WHERE str_record_col = '"str1"=>"str 2", "str2"=>"str 3", "str3"=>"str 4"'::hstore;
```
```
[info]   quals {
[info]     name: "str_record_col"
[info]     simple_qual {
[info]       value {
[info]         record {
[info]           atts {
[info]             name: "str1"
[info]             value {
[info]               string {
[info]                 v: "str 2"
[info]               }
[info]             }
[info]           }
[info]           atts {
[info]             name: "str2"
[info]             value {
[info]               string {
[info]                 v: "str 3"
[info]               }
[info]             }
[info]           }
[info]           atts {
[info]             name: "str3"
[info]             value {
[info]               string {
[info]                 v: "str 4"
[info]               }
[info]             }
[info]           }
[info]         }
[info]       }
[info]     }
[info]   }
```
## HSTORE arrays
```sql
SELECT str_record_col, str_records_col, record_col, records_col
FROM test.all_types
WHERE str_records_col = ARRAY['"str1"=>"str 2", "str2"=>"str 3", "str3"=>"str 4"'::hstore];
```
```
[info] query {
[info]   quals {
[info]     name: "str_records_col"
[info]     simple_qual {
[info]       value {
[info]         list {
[info]           values {
[info]             record {
[info]               atts {
[info]                 name: "str1"
[info]                 value {
[info]                   string {
[info]                     v: "str 2"
[info]                   }
[info]                 }
[info]               }
[info]               atts {
[info]                 name: "str2"
[info]                 value {
[info]                   string {
[info]                     v: "str 3"
[info]                   }
[info]                 }
[info]               }
[info]               atts {
[info]                 name: "str3"
[info]                 value {
[info]                   string {
[info]                     v: "str 4"
[info]                   }
[info]                 }
[info]               }
[info]             }
[info]           }
[info]         }
[info]       }
[info]     }
[info]   }
```
```sql
SELECT str_record_col, str_records_col, record_col, records_col
FROM test.all_types
WHERE str_records_col = '{"\"str1\"=>\"str 2\", \"str2\"=>\"str 3\", \"str3\"=>\"str 4\"","\"str1\"=>\"str 3\", \"str2\"=>\"str 4\", \"str3\"=>\"str 5\"","\"str1\"=>\"str 4\", \"str2\"=>\"str 5\", \"str3\"=>\"str 6\"","\"str1\"=>\"str 5\", \"str2\"=>\"str 6\", \"str3\"=>\"str 7\""}'::_hstore;
```
```
[info] query {
[info]   quals {
[info]     name: "str_records_col"
[info]     simple_qual {
[info]       value {
[info]         list {
[info]           values {
[info]             record {
[info]               atts {
[info]                 name: "str1"
[info]                 value {
[info]                   string {
[info]                     v: "str 2"
[info]                   }
[info]                 }
[info]               }
....
[info]           }
[info]         }
[info]       }
[info]     }
[info]   }
```