### PR TITLE
RD-15410: DAS function support

### DIFF
--- a/python/multicorn/__init__.py
+++ b/python/multicorn/__init__.py
@@ -512,6 +512,39 @@ class TransactionAwareForeignDataWrapper(ForeignDataWrapper):
         self._init_transaction_state()
 
 
+class ForeignFunction(object):
+    """
+    Class that represents an RPC-like function call from DAS, exposed as a Postgres function.
+    It can call the remote function via gRPC and return the result.
+    """
+    def execute(
+        self,
+        named_args=None,
+        env=None
+    ):
+        """
+        Execute the remote function.
+        """
+        pass
+
+    @classmethod
+    def execute_static(cls, options, named_args=None, env=None):
+        """
+        One-shot static helper to create a temporary ForeignFunction instance,
+        call execute(), and return the result.
+        """
+
+        # TODO instances could be cached by the options they were configured with, to avoid
+        # recreating a new gRPC channel
+
+        ephemeral = cls(options)
+
+        return ephemeral.execute(
+            named_args=named_args or {},
+            env=env
+        )
+
+
 """Code from python2.7 importlib.import_module."""
 """Backport of importlib.import_module from 3.x."""
 # While not critical (and in no way guaranteed!), it would be nice to keep this


### PR DESCRIPTION
(Goes with https://github.com/raw-labs/multicorn-das/pull/28)

This PR adds DAS function support to multicorn by introducing:
* A new C function entry point `multicorn_function_execute`, which can be invoked
  from SQL with a set of parameters that includes FDW-like options, named
  argument strings, and the actual function parameters.
* A bridging helper function `das_function_execute` that:
  * Converts `options` and `arguments` into Python dictionaries,
  * Dynamically imports and calls the Python module/class (`multicorn_das.DASFunction.execute_static`) for DAS function execution,
  * Then converts the Python result back into a PostgreSQL `Datum`.
* An auxiliary function `build_dummy_attinmeta(Oid retType)` for creating a
  single-column `AttInMetadata` structure, used when converting the returned
  Python object to a `Datum` of the indicated `retType`. If the return type is an
  array, it sets attndims=1 to handle array‐like results.

A fix:
* `INTERVAL` was read from a `dict` representation, that isn't anything standard (it is the Python object generated by `multicorn-das`), to turn it into an ISO string which Postgres can parse and import. If `multicorn-das` generates that a Python ISO string instead of that dictionary, then importing an interval is simplified: we can pass the string to Postgres.
* That implementation also helps with extracting fields from a JSONB returned by a DAS function: if the JSONB contains the JSON representation of the original Python `dict`, a user wouldn't easily translate it into a Postgres `INTERVAL`, while if it comes as an ISO string, `value::interval` works.

## multicorn_function_execute

Runs the logic to execute a DAS function statically.
* It receives at least two arguments:
  * a `text[]` of options, which permits to identify which DAS and function to execute,
  * and a `text[]` of parameter names, which is used eventually to build the named arguments as a Python dictionary,
  * plus N further actual arguments for the DAS function.
* The argument/return types are retrieved from `pg_proc`, in order to calls `foreign_function_execute`, that bridges to Python.

## foreign_function_execute

It bridges the SQL function to Python:
* Converts FDW options to a Python dict.
* Converts named function arguments to another dict.
* Imports `multicorn_das.DASFunction` and calls `execute_static(...)`.
* Uses `pyobjectToDatum(...)` to transform the Python result to a Postgres Datum.

## build_dummy_attinmeta

Converting the function result to `Datum` reuses the existing Python conversion
code that runs for tables.  Because that code takes its conversion information
from column descriptions, we add `build_dummy_attinmeta`, a function that
returns a single‐attribute `AttInMetadata` with the given type for the required
text-based conversion that are already in place for column values.