### PR TITLE
Fixed RD-15494: Fetch scopes and HTTP headers from specific Postgres GUC variables

### DIFF
--- a/python/multicorn/__init__.py
+++ b/python/multicorn/__init__.py
@@ -269,7 +269,7 @@ class ForeignDataWrapper(object):
         """
         return []
 
-    def explain(self, env, quals, columns, sortkeys=None, limit=None, verbose=False):
+    def explain(self, quals, columns, sortkeys=None, limit=None, verbose=False, scopes=None, http_headers=None):
         """Hook called on explain.
 
         The arguments are the same as the :meth:`execute`, with the addition of
@@ -280,7 +280,7 @@ class ForeignDataWrapper(object):
         """
         return []
 
-    def execute(self, env, quals, columns, sortkeys=None, limit=None, planid=None):
+    def execute(self, quals, columns, sortkeys=None, limit=None, planid=None, scopes=None, http_headers=None):
         """Execute a query in the foreign data wrapper.
 
         This method is called at the first iteration.
@@ -520,7 +520,8 @@ class ForeignFunction(object):
     def execute(
         self,
         named_args=None,
-        env=None
+        scopes=None,
+        http_headers=None
     ):
         """
         Execute the remote function.
@@ -528,7 +529,7 @@ class ForeignFunction(object):
         pass
 
     @classmethod
-    def execute_static(cls, options, named_args=None, env=None):
+    def execute_static(cls, options, named_args=None, scopes=None, http_headers=None):
         """
         One-shot static helper to create a temporary ForeignFunction instance,
         call execute(), and return the result.
@@ -541,7 +542,8 @@ class ForeignFunction(object):
 
         return ephemeral.execute(
             named_args=named_args or {},
-            env=env
+            scopes=scopes,
+            http_headers=http_headers
         )
 
 

--- a/src/multicorn.c
+++ b/src/multicorn.c
@@ -30,6 +30,7 @@
 #include "fmgr.h"
 #include "port/atomics.h"
 #include "catalog/namespace.h"
+#include "utils/guc.h"
 
 #if PG_VERSION_NUM >= 130000
 #include "common/hashfn.h" /* oid_hash */
@@ -138,6 +139,8 @@ HTAB	   *InstancesHash;
 static int fdw_unique_id;
 static pg_atomic_uint64 global_query_counter;
 
+static char *raw_http_headers = NULL;
+static char *raw_scopes = NULL;
 
 void
 _PG_init()
@@ -203,6 +206,22 @@ _PG_init()
 
     }
     MemoryContextSwitchTo(oldctx);
+    DefineCustomStringVariable("my.raw_http_headers",
+                               "A variable for passing HTTP headers (JSON array of objects with header/value).",
+                               "HTTP headers (in JSON)",
+                               &raw_http_headers ,        /* pointer to our global variable */
+                               NULL,                     /* default value (none) */
+                               PGC_USERSET,              /* can be set by the user */
+                               0,                        /* flags */
+                               NULL, NULL, NULL);
+    DefineCustomStringVariable("my.raw_scopes",
+                               "A variable for passing scopes (JSON array of strings).",
+                               "Scopes (in JSON)",
+                               &raw_scopes,
+                               NULL,                     /* default value (none) */
+                               PGC_USERSET,              /* can be set by the user */
+                               0,                        /* flags */
+                               NULL, NULL, NULL);
 }
 
 void


### PR DESCRIPTION
Originally the content of the temporary table `environment` was read and passed as `env` to the Python code. Now we want to read HTTP headers instead (not a generic environment) and send them. Same for the scope tokens.

We expect HTTP headers and scopes in JSON strings stored in the following variables:
```sql
set my.raw_http_headers = '[{"header": "Accept", "value":"text/css"}, {"header": "Content-Length", "value": "188"}]';
set my.raw_scopes = '["DEV", "ADMIN"]';
```
When combined with a DAS that returns them as tables:
```
# SELECT * FROM environment.http_headers ;
     header     |  value   
----------------+----------
 Accept         | text/css
 Content-Length | 188
(2 rows)

# SELECT * FROM environment.scopes;
 token 
-------
 DEV
 ADMIN
(2 rows)
```
