### PR TITLE
Fixed RD-15552: DAS functions broken after passing HTTP headers and scopes

### DIFF
--- a/src/python.c
+++ b/src/python.c
@@ -2586,7 +2586,7 @@ foreign_function_execute(List *options_list, int nArgs, char **argNames,  Oid *a
      *   - a dict of options,
      *   - a dict of arguments keyed by name.
      */
-    PyObject *call_args = PyTuple_New(3);
+    PyObject *call_args = PyTuple_New(2);
     PyTuple_SetItem(call_args, 0, option_dict);  /* tuple takes ownership */
     PyTuple_SetItem(call_args, 1, py_argdict);   /* tuple takes ownership */
 


### PR DESCRIPTION
Half the code had been fixed and this wasn't tested. The Python layer crashes because we allocate a tuple of size three, but only fill two items.

Just running a foreign function is enough to spot the problem. With that patch, one can execute functions.